### PR TITLE
Added an 'include graph' to handle potential infinite recursion more gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
 dist/*
+scratch/*
 mdoc.egg-info*
 *.pyc


### PR DESCRIPTION
A directed graph is continually updated and checked for cycles when
a new file is included. If a cycle is found, an exception is raised,
the file which calls itself is printed, as well as the entire include
graph.

Resolves #2.